### PR TITLE
python clean up

### DIFF
--- a/.config/pythonrc
+++ b/.config/pythonrc
@@ -1,0 +1,12 @@
+import atexit, os, readline
+
+histfile=os.path.join(os.path.expanduser("~/.config/python"),"python_history")
+
+try:
+    readline.read_history_file(histfile)
+    #default history len is -1 (infinite), which may grow unruly
+    readline.set_history_length(1000)
+except FileNotFoundError:
+    pass
+
+atexit.register(readline.write_history_file,histfile)

--- a/.zprofile
+++ b/.zprofile
@@ -34,6 +34,7 @@ export ANDROID_SDK_HOME="${XDG_CONFIG_HOME:-$HOME/.config}/android"
 export CARGO_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/cargo"
 export GOPATH="${XDG_DATA_HOME:-$HOME/.local/share}/go"
 export ANSIBLE_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/ansible/ansible.cfg"
+export PYTHONSTARTUP="${XDG_CONFIG_HOME:-$HOME/.config}/pythonrc"
 
 # Other program settings:
 export DICS="/usr/share/stardict/dic/"


### PR DESCRIPTION
python command line drops its history file ~/.
This script tells python to {look in/place the} the python_history file in ~/.config directory  
The script is read  via the environment variable $PYTHONSTARTUP